### PR TITLE
Reset objects after each IT test class

### DIFF
--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/integration/AbstractRolesIT.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/integration/AbstractRolesIT.java
@@ -21,6 +21,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -38,21 +48,12 @@ import org.apache.http.message.AbstractHttpMessage;
 import org.apache.http.util.EntityUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.Arrays;
-import java.util.ArrayList;
 
 /**
  * @author Gregory Jansen
@@ -103,6 +104,11 @@ public abstract class AbstractRolesIT {
             is_setup = true;
             logger.info("SETUP SUCCESSFUL");
         }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        is_setup = false;
     }
 
     public int canRead(final String username, final String path,


### PR DESCRIPTION
Run setup again with every test class, in order to reset state.  We do not use @BeforeClass for the setup, as there are several methods called during setup that are not static;  the before/after class annotations require that the methods be static.
