### PR TITLE
story 81846720. Fix fcrepo-module-auth-rbacl/xacml.

### DIFF
--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
@@ -41,19 +41,20 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.hp.hpl.jena.rdf.model.Resource;
 import org.fcrepo.http.commons.AbstractResource;
 import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
-import org.fcrepo.kernel.FedoraBinary;
-import org.fcrepo.kernel.FedoraResource;
 import org.fcrepo.kernel.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.models.FedoraBinary;
+import org.fcrepo.kernel.models.FedoraResource;
+
 import org.jvnet.hk2.annotations.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.common.annotations.VisibleForTesting;
+import com.hp.hpl.jena.rdf.model.Resource;
 
 /**
  * RESTful interface to create and manage access roles

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesResources.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesResources.java
@@ -24,7 +24,7 @@ import javax.ws.rs.core.UriInfo;
 
 import org.fcrepo.http.commons.api.rdf.UriAwareResourceModelFactory;
 import org.fcrepo.jcr.FedoraJcrTypes;
-import org.fcrepo.kernel.FedoraResource;
+import org.fcrepo.kernel.models.FedoraResource;
 import org.fcrepo.kernel.RdfLexicon;
 import org.fcrepo.kernel.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.identifiers.IdentifierConverter;

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesResourcesTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesResourcesTest.java
@@ -29,7 +29,7 @@ import javax.jcr.Session;
 import javax.ws.rs.core.UriInfo;
 
 import org.fcrepo.jcr.FedoraJcrTypes;
-import org.fcrepo.kernel.FedoraResource;
+import org.fcrepo.kernel.models.FedoraResource;
 import org.fcrepo.kernel.RdfLexicon;
 import org.fcrepo.kernel.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.impl.rdf.impl.DefaultIdentifierTranslator;

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesTest.java
@@ -44,7 +44,7 @@ import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 
-import org.fcrepo.kernel.FedoraResource;
+import org.fcrepo.kernel.models.FedoraResource;
 import org.fcrepo.kernel.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.services.NodeService;
 import org.junit.Before;
@@ -95,7 +95,7 @@ public class AccessRolesTest {
 
         when(session.getNode("/some/path")).thenReturn(mockNode);
 
-        when(nodeService.getObject(any(Session.class), anyString()))
+        when(nodeService.find(any(Session.class), anyString()))
                 .thenReturn(fedoraResource);
 
     }


### PR DESCRIPTION
Updated rbacl module in accordance to fedora model object renames and package changes. (https://github.com/fcrepo4/fcrepo4/commit/9b6bd6f5bbcfb045a4f7fd9a7e0536efb3bb6126)

https://www.pivotaltracker.com/story/show/81846720
