### PR TITLE
normalize configuration values

### DIFF
--- a/fcrepo-auth-roles-basic/src/test/resources/logback-test.xml
+++ b/fcrepo-auth-roles-basic/src/test/resources/logback-test.xml
@@ -7,10 +7,10 @@
         </encoder>
     </appender>
 
-    <logger name="org.fcrepo.auth" additivity="false" level="${log.fcrepo.auth:-DEBUG}">
+    <logger name="org.fcrepo.auth" additivity="false" level="${fcrepo.log.auth:-DEBUG}">
         <appender-ref ref="STDOUT"/>
     </logger>
-    <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+    <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
         <appender-ref ref="STDOUT"/>
     </logger>
     <root additivity="false" level="WARN">

--- a/fcrepo-auth-roles-basic/src/test/resources/repository.json
+++ b/fcrepo-auth-roles-basic/src/test/resources/repository.json
@@ -8,10 +8,10 @@
     },
     "storage" : {
         "cacheName" : "FedoraRepository",
-        "cacheConfiguration" : "${fcrepo.infinispan.cache_configuration:config/infinispan/leveldb-default/infinispan.xml}",
+        "cacheConfiguration" : "${fcrepo.ispn.configuration:config/infinispan/leveldb-default/infinispan.xml}",
         "binaryStorage" : {
             "type" : "file",
-            "directory" : "${fcrepo.binary-store-path:target/binaries}",
+            "directory" : "${fcrepo.binary.directory:target/binaries}",
             "minimumBinarySizeInBytes" : 4096
         }
     },

--- a/fcrepo-auth-roles-basic/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-auth-roles-basic/src/test/resources/spring-test/test-container.xml
@@ -13,7 +13,7 @@
   </bean>
   
   <bean id="containerWrapper" class="org.fcrepo.http.commons.test.util.ContainerWrapper" init-method="start" destroy-method="stop" >
-    <property name="port" value="${test.port:8080}"/>
+    <property name="port" value="${fcrepo.test.port:8080}"/>
     <property name="configLocation" value="classpath:web.xml" />
   </bean>
   

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/integration/AbstractRolesIT.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/integration/AbstractRolesIT.java
@@ -68,7 +68,7 @@ public abstract class AbstractRolesIT {
     private static Logger logger = getLogger(AbstractRolesIT.class);
 
     protected static final int SERVER_PORT = Integer.parseInt(System
-            .getProperty("test.port", "8080"));
+            .getProperty("fcrepo.test.port", "8080"));
 
     protected static final String HOSTNAME = "localhost";
 

--- a/fcrepo-auth-roles-common/src/test/resources/logback-test.xml
+++ b/fcrepo-auth-roles-common/src/test/resources/logback-test.xml
@@ -7,10 +7,10 @@
         </encoder>
     </appender>
 
-    <logger name="org.fcrepo.auth" additivity="false" level="${log.fcrepo.auth:-INFO}">
+    <logger name="org.fcrepo.auth" additivity="false" level="${fcrepo.log.auth:-INFO}">
         <appender-ref ref="STDOUT"/>
     </logger>
-    <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+    <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
         <appender-ref ref="STDOUT"/>
     </logger>
     <root additivity="false" level="WARN">

--- a/fcrepo-auth-roles-common/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-auth-roles-common/src/test/resources/spring-test/test-container.xml
@@ -13,7 +13,7 @@
   </bean>
   
   <bean id="containerWrapper" class="org.fcrepo.http.commons.test.util.ContainerWrapper" init-method="start" destroy-method="stop" >
-    <property name="port" value="${test.port:8080}"/>
+    <property name="port" value="${fcrepo.test.port:8080}"/>
     <property name="configLocation" value="classpath:web.xml" />
   </bean>
   


### PR DESCRIPTION
related to https://jira.duraspace.org/browse/FCREPO-1288

This changes some of the configuration values to match the proposed changes to fcrepo4 including:

`log.fcrepo*` => `fcrepo.log*`
`fcrepo.binary-store-path` => `fcrepo.binary.directory`
`fcrepo.infinispan.cache_configuration` => `fcrepo.ispn.configuration`
`test.port` => `fcrepo.test.port`