### PR TITLE
fixed documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ fcrepo-module-auth-rbacl
 
 Role Based Authorization Delegate Module for the Fedora 4 Repository
 
-This module is based on the design documented here: https://wiki.duraspace.org/display/FF/Basic+Role-based+Authorization+Delegate
+This module is based on the design documented here: https://wiki.duraspace.org/display/FEDORA4x/Basic+Role-based+Authorization+Delegate


### PR DESCRIPTION
The link in the documentation pointed to an old location.