### PR TITLE
Rename dynamic build properties for clarity

### DIFF
--- a/fcrepo-auth-roles-basic/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-auth-roles-basic/src/test/resources/spring-test/test-container.xml
@@ -13,7 +13,7 @@
   </bean>
   
   <bean id="containerWrapper" class="org.fcrepo.http.commons.test.util.ContainerWrapper" init-method="start" destroy-method="stop" >
-    <property name="port" value="${fcrepo.test.port:8080}"/>
+    <property name="port" value="${fcrepo.dynamic.test.port:8080}"/>
     <property name="configLocation" value="classpath:web.xml" />
   </bean>
   

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/integration/AbstractRolesIT.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/integration/AbstractRolesIT.java
@@ -68,7 +68,7 @@ public abstract class AbstractRolesIT {
     private static Logger logger = getLogger(AbstractRolesIT.class);
 
     protected static final int SERVER_PORT = Integer.parseInt(System
-            .getProperty("fcrepo.test.port", "8080"));
+            .getProperty("fcrepo.dynamic.test.port", "8080"));
 
     protected static final String HOSTNAME = "localhost";
 

--- a/fcrepo-auth-roles-common/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-auth-roles-common/src/test/resources/spring-test/test-container.xml
@@ -13,7 +13,7 @@
   </bean>
   
   <bean id="containerWrapper" class="org.fcrepo.http.commons.test.util.ContainerWrapper" init-method="start" destroy-method="stop" >
-    <property name="port" value="${fcrepo.test.port:8080}"/>
+    <property name="port" value="${fcrepo.dynamic.test.port:8080}"/>
     <property name="configLocation" value="classpath:web.xml" />
   </bean>
   


### PR DESCRIPTION
The build-helper-maven-plugin is used to generate properties for dynamic
port configuration. This commit marks these properties with the word
`dynamic` to highlight that fact, e.g. `fcrepo.dynamic.test.port`.