### PR TITLE
renamed fcrepo-kernel* modules based on upstream changes

### DIFF
--- a/fcrepo-auth-roles-basic/pom.xml
+++ b/fcrepo-auth-roles-basic/pom.xml
@@ -107,7 +107,7 @@
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
-      <artifactId>fcrepo-kernel-impl</artifactId>
+      <artifactId>fcrepo-kernel-modeshape</artifactId>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegateRemoveChildrenRecursiveTest.java
+++ b/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegateRemoveChildrenRecursiveTest.java
@@ -21,7 +21,7 @@ import static java.util.Collections.singletonMap;
 import static org.fcrepo.auth.common.FedoraAuthorizationDelegate.FEDORA_ALL_PRINCIPALS;
 import static org.fcrepo.auth.common.FedoraAuthorizationDelegate.FEDORA_USER_PRINCIPAL;
 import static org.fcrepo.http.commons.test.util.TestHelpers.setField;
-import static org.fcrepo.kernel.impl.testutilities.TestNodeIterator.nodeIterator;
+import static org.fcrepo.kernel.modeshape.testutilities.TestNodeIterator.nodeIterator;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;

--- a/fcrepo-auth-roles-basic/src/test/resources/spring-test/repo.xml
+++ b/fcrepo-auth-roles-basic/src/test/resources/spring-test/repo.xml
@@ -9,7 +9,7 @@
 
   <context:annotation-config />
   
-  <bean name="modeshapeRepofactory" class="org.fcrepo.kernel.impl.spring.ModeShapeRepositoryFactoryBean"
+  <bean name="modeshapeRepofactory" class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
     depends-on="authenticationProvider">
     <property name="repositoryConfiguration" value="${fcrepo.modeshape.configuration:repository.json}" />
   </bean>

--- a/fcrepo-auth-roles-basic/src/test/resources/spring-test/rest.xml
+++ b/fcrepo-auth-roles-basic/src/test/resources/spring-test/rest.xml
@@ -19,9 +19,9 @@
   <bean class="org.fcrepo.mint.UUIDPidMinter"/>
 
   <!-- Identifier translation chain -->
-  <util:list id="translationChain" value-type="org.fcrepo.kernel.identifiers.InternalIdentifierConverter">
-    <bean class="org.fcrepo.kernel.impl.identifiers.HashConverter"/>
-    <bean class="org.fcrepo.kernel.impl.identifiers.NamespaceConverter"/>
+  <util:list id="translationChain" value-type="org.fcrepo.kernel.api.identifiers.InternalIdentifierConverter">
+    <bean class="org.fcrepo.kernel.modeshape.identifiers.HashConverter"/>
+    <bean class="org.fcrepo.kernel.modeshape.identifiers.NamespaceConverter"/>
   </util:list>
 
   <context:component-scan base-package="org.fcrepo"/>

--- a/fcrepo-auth-roles-common/pom.xml
+++ b/fcrepo-auth-roles-common/pom.xml
@@ -92,7 +92,7 @@
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
-      <artifactId>fcrepo-kernel-impl</artifactId>
+      <artifactId>fcrepo-kernel-modeshape</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AbstractRolesAuthorizationDelegate.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AbstractRolesAuthorizationDelegate.java
@@ -29,7 +29,7 @@ import javax.jcr.Session;
 
 import org.fcrepo.auth.common.FedoraAuthorizationDelegate;
 import org.fcrepo.http.commons.session.SessionFactory;
-import org.fcrepo.kernel.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.modeshape.jcr.value.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
@@ -43,9 +43,9 @@ import javax.ws.rs.core.UriInfo;
 
 import org.fcrepo.http.commons.AbstractResource;
 import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
-import org.fcrepo.kernel.identifiers.IdentifierConverter;
-import org.fcrepo.kernel.models.FedoraBinary;
-import org.fcrepo.kernel.models.FedoraResource;
+import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraBinary;
+import org.fcrepo.kernel.api.models.FedoraResource;
 
 import org.jvnet.hk2.annotations.Optional;
 import org.slf4j.Logger;

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesProvider.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesProvider.java
@@ -30,7 +30,7 @@ import javax.jcr.Session;
 import javax.jcr.Value;
 
 import org.fcrepo.auth.roles.common.Constants.JcrName;
-import org.fcrepo.kernel.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.modeshape.jcr.value.Path;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesResources.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesResources.java
@@ -23,11 +23,11 @@ import javax.jcr.RepositoryException;
 import javax.ws.rs.core.UriInfo;
 
 import org.fcrepo.http.commons.api.rdf.UriAwareResourceModelFactory;
-import org.fcrepo.kernel.FedoraJcrTypes;
-import org.fcrepo.kernel.models.FedoraResource;
-import org.fcrepo.kernel.RdfLexicon;
-import org.fcrepo.kernel.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.FedoraJcrTypes;
+import org.fcrepo.kernel.api.RdfLexicon;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraResource;
 import org.springframework.stereotype.Component;
 
 import com.hp.hpl.jena.rdf.model.Model;
@@ -45,8 +45,8 @@ public class AccessRolesResources implements UriAwareResourceModelFactory {
     /*
      * (non-Javadoc)
      * @see org.fcrepo.http.commons.api.rdf.UriAwareResourceModelFactory#
-     * createModelForResource( org.fcrepo.kernel.FedoraResourceImpl,
-     * javax.ws.rs.core.UriInfo, org.fcrepo.kernel.rdf.IdentifierTranslator)
+     * createModelForResource( org.fcrepo.kernel.api.FedoraResourceImpl,
+     * javax.ws.rs.core.UriInfo, org.fcrepo.kernel.api.rdf.IdentifierTranslator)
      */
     @Override
     public Model createModelForResource(final FedoraResource resource,

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesTypes.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesTypes.java
@@ -25,7 +25,7 @@ import javax.jcr.nodetype.NodeType;
 import javax.jcr.nodetype.NodeTypeIterator;
 
 import org.fcrepo.http.commons.session.SessionFactory;
-import org.fcrepo.kernel.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.modeshape.jcr.api.nodetype.NodeTypeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesProviderTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesProviderTest.java
@@ -20,7 +20,7 @@ import static org.fcrepo.auth.roles.common.Constants.JcrName.principal;
 import static org.fcrepo.auth.roles.common.Constants.JcrName.rbacl;
 import static org.fcrepo.auth.roles.common.Constants.JcrName.rbaclAssignable;
 import static org.fcrepo.auth.roles.common.Constants.JcrName.role;
-import static org.fcrepo.kernel.impl.testutilities.TestNodeIterator.nodeIterator;
+import static org.fcrepo.kernel.modeshape.testutilities.TestNodeIterator.nodeIterator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesResourcesTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesResourcesTest.java
@@ -28,11 +28,11 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.ws.rs.core.UriInfo;
 
-import org.fcrepo.kernel.FedoraJcrTypes;
-import org.fcrepo.kernel.models.FedoraResource;
-import org.fcrepo.kernel.RdfLexicon;
-import org.fcrepo.kernel.identifiers.IdentifierConverter;
-import org.fcrepo.kernel.impl.rdf.impl.DefaultIdentifierTranslator;
+import org.fcrepo.kernel.api.FedoraJcrTypes;
+import org.fcrepo.kernel.api.RdfLexicon;
+import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.modeshape.rdf.impl.DefaultIdentifierTranslator;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesTest.java
@@ -44,9 +44,9 @@ import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 
-import org.fcrepo.kernel.models.FedoraResource;
-import org.fcrepo.kernel.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.services.NodeService;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.services.NodeService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesTypesTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesTypesTest.java
@@ -34,7 +34,7 @@ import javax.jcr.nodetype.NodeType;
 import javax.jcr.nodetype.NodeTypeIterator;
 
 import org.fcrepo.http.commons.session.SessionFactory;
-import org.fcrepo.kernel.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/fcrepo-auth-roles-common/src/test/resources/spring-test/repo.xml
+++ b/fcrepo-auth-roles-common/src/test/resources/spring-test/repo.xml
@@ -9,7 +9,7 @@
 
   <context:annotation-config />
 
-  <bean name="modeshapeRepofactory" class="org.fcrepo.kernel.impl.spring.ModeShapeRepositoryFactoryBean">
+  <bean name="modeshapeRepofactory" class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean">
     <property name="repositoryConfiguration" value="${fcrepo.modeshape.configuration:config/minimal-default/repository.json}" />
   </bean>
 

--- a/fcrepo-auth-roles-common/src/test/resources/spring-test/rest.xml
+++ b/fcrepo-auth-roles-common/src/test/resources/spring-test/rest.xml
@@ -19,9 +19,9 @@
   <bean class="org.fcrepo.mint.UUIDPidMinter"/>
 
   <!-- Identifier translation chain -->
-  <util:list id="translationChain" value-type="org.fcrepo.kernel.identifiers.InternalIdentifierConverter">
-    <bean class="org.fcrepo.kernel.impl.identifiers.HashConverter"/>
-    <bean class="org.fcrepo.kernel.impl.identifiers.NamespaceConverter"/>
+  <util:list id="translationChain" value-type="org.fcrepo.kernel.api.identifiers.InternalIdentifierConverter">
+    <bean class="org.fcrepo.kernel.modeshape.identifiers.HashConverter"/>
+    <bean class="org.fcrepo.kernel.modeshape.identifiers.NamespaceConverter"/>
   </util:list>
 
   <context:component-scan base-package="org.fcrepo"/>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
       </dependency>
       <dependency>
         <groupId>org.fcrepo</groupId>
-        <artifactId>fcrepo-kernel-impl</artifactId>
+        <artifactId>fcrepo-kernel-modeshape</artifactId>
         <version>4.2.1-SNAPSHOT</version>
         <classifier>tests</classifier>
       </dependency>


### PR DESCRIPTION
See: https://jira.duraspace.org/browse/FCREPO-1641

Note: the travis build will fail until https://github.com/fcrepo4/fcrepo4/pull/846 is merged