### PR TITLE
Remove auto-registration of the AccessRolesResources component.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 target/
+fcrepo4-data
 
 # Eclipse specific files
 .settings

--- a/fcrepo-auth-roles-basic/src/test/resources/spring-test/repo.xml
+++ b/fcrepo-auth-roles-basic/src/test/resources/spring-test/repo.xml
@@ -18,6 +18,9 @@
     <property name="fad" ref="fad"/>
   </bean>
   
+  <!-- Add the fcr:accessroles resource -->
+  <bean name="accessRolesResources" class="org.fcrepo.auth.roles.common.AccessRolesResources"/>
+  
   <bean name="fad" class="org.fcrepo.auth.roles.basic.BasicRolesAuthorizationDelegate"/>
 
     <bean class="org.modeshape.jcr.ModeShapeEngine" init-method="start"/>

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
@@ -72,7 +72,7 @@ public class AccessRoles extends AbstractResource {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(AccessRoles.class);
 
-    protected IdentifierConverter<Resource,FedoraResource> identifierTranslator;
+    protected IdentifierConverter<Resource, FedoraResource> identifierTranslator;
 
 
     @Inject
@@ -137,14 +137,19 @@ public class AccessRoles extends AbstractResource {
                 node = getJcrNode(resource());
             }
 
-            final Map<String, Collection<String>> data =
-                    this.getAccessRolesProvider().getRoles(node,
-                            (effective != null));
-            if (data == null) {
-                LOGGER.debug("no content response");
-                response = Response.noContent();
+            final AccessRolesProvider provider = this.getAccessRolesProvider();
+            if (provider == null) {
+                LOGGER.debug("accessRolesProvider is null");
+                response = Response.status(Status.NOT_FOUND);
             } else {
-                response = Response.ok(data);
+                final Map<String, Collection<String>> data =
+                        provider.getRoles(node, (effective != null));
+                if (data == null) {
+                    LOGGER.debug("no content response");
+                    response = Response.noContent();
+                } else {
+                    response = Response.ok(data);
+                }
             }
         } finally {
             session.logout();
@@ -163,7 +168,7 @@ public class AccessRoles extends AbstractResource {
     @Consumes(APPLICATION_JSON)
     @Timed
     public Response post(final Map<String, Set<String>> data)
-        throws RepositoryException {
+            throws RepositoryException {
         LOGGER.debug("POST Received request param: {}", request);
         Response.ResponseBuilder response;
 
@@ -257,7 +262,7 @@ public class AccessRoles extends AbstractResource {
     }
 
 
-    protected IdentifierConverter<Resource,FedoraResource> translator() {
+    protected IdentifierConverter<Resource, FedoraResource> translator() {
         if (identifierTranslator == null) {
             identifierTranslator = new HttpResourceConverter(session,
                     uriInfo.getBaseUriBuilder().clone().path("{path: .*}"));

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesResources.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesResources.java
@@ -28,7 +28,6 @@ import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.RdfLexicon;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
-import org.springframework.stereotype.Component;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
@@ -39,7 +38,6 @@ import com.hp.hpl.jena.rdf.model.Resource;
  *
  * @author Gregory Jansen
  */
-@Component
 public class AccessRolesResources implements UriAwareResourceModelFactory {
 
     /*


### PR DESCRIPTION
- Require auth modules that use fcr:accessroles to explicitly add it to their repo.xml Spring configuration
- If fcr:accessroles is requested but is not supported by the current FAD, respond with a 404 instead of throwing a null pointer exception
- Configure RBACL to use fcr:accessroles

Resolves: https://jira.duraspace.org/browse/FCREPO-1853