### PR TITLE
make modeshape dependency explicit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
       </dependency>
       <dependency>
         <groupId>org.fcrepo</groupId>
+        <artifactId>fcrepo-kernel-modeshape</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.fcrepo</groupId>
         <artifactId>fcrepo-http-api</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
The fcrepo-module-auth-rbacl module depends on fcrepo-kernel-modeshape, but that dependency is not made explicit (hence the fact that it will not currently compile).