### PR TITLE
Follow-on to removal of jcr.Session from the kernel-api

### DIFF
--- a/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegateRemoveChildrenRecursiveTest.java
+++ b/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegateRemoveChildrenRecursiveTest.java
@@ -27,13 +27,15 @@ import static org.fcrepo.kernel.modeshape.testutilities.TestNodeIterator.nodeIte
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import org.fcrepo.auth.roles.common.AccessRolesProvider;
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.modeshape.jcr.value.Path;
 
 import javax.jcr.Node;
@@ -48,6 +50,7 @@ import java.util.Set;
 /**
  * @author Mike Daines
  */
+@RunWith(MockitoJUnitRunner.class)
 public class BasicRolesAuthorizationDelegateRemoveChildrenRecursiveTest {
 
     private static final String[] REMOVE_ACTION = {"remove"};
@@ -64,44 +67,28 @@ public class BasicRolesAuthorizationDelegateRemoveChildrenRecursiveTest {
     private Session mockSession;
 
     @Mock
+    private FedoraSessionImpl mockFedoraSession;
+
+    @Mock
     private Principal principal;
 
     private Set<Principal> allPrincipals;
 
     @Mock
-    private Path parentPath;
+    private Path parentPath, writablePath, readablePath, noAclPath;
 
     @Mock
-    private Node parentNode;
-
-    @Mock
-    private Path writablePath;
-
-    @Mock
-    private Node writableNode;
-
-    @Mock
-    private Path readablePath;
-
-    @Mock
-    private Node readableNode;
-
-    @Mock
-    private Path noAclPath;
-
-    @Mock
-    private Node noAclNode;
+    private Node parentNode, writableNode, readableNode, noAclNode;
 
     @Before
     public void setUp() throws RepositoryException {
-        initMocks(this);
-
         authorizationDelegate = new BasicRolesAuthorizationDelegate();
         setField(authorizationDelegate, "accessRolesProvider",
                 accessRolesProvider);
         setField(authorizationDelegate, "sessionFactory", sessionFactory);
 
-        when(sessionFactory.getInternalSession()).thenReturn(mockSession);
+        when(sessionFactory.getInternalSession()).thenReturn(mockFedoraSession);
+        when(mockFedoraSession.getJcrSession()).thenReturn(mockSession);
 
         when(principal.getName()).thenReturn("user");
         allPrincipals = singleton(principal);

--- a/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegateTest.java
+++ b/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegateTest.java
@@ -26,14 +26,16 @@ import static org.fcrepo.http.commons.test.util.TestHelpers.setField;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
+import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 import org.fcrepo.auth.roles.common.AccessRolesProvider;
 import org.fcrepo.auth.roles.common.Constants.JcrName;
 import org.fcrepo.http.commons.session.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.modeshape.jcr.value.Path;
 
 import javax.jcr.RepositoryException;
@@ -48,6 +50,7 @@ import java.util.Set;
 /**
  * @author Mike Daines
  */
+@RunWith(MockitoJUnitRunner.class)
 public class BasicRolesAuthorizationDelegateTest {
 
     private static final String[] READ_ACTION = {"read"};
@@ -61,6 +64,9 @@ public class BasicRolesAuthorizationDelegateTest {
 
     @Mock
     private SessionFactory sessionFactory;
+
+    @Mock
+    private FedoraSessionImpl mockFedoraSession;
 
     @Mock
     private Session mockSession;
@@ -90,18 +96,17 @@ public class BasicRolesAuthorizationDelegateTest {
 
     @Before
     public void setUp() throws RepositoryException {
-        initMocks(this);
-
         authorizationDelegate = new BasicRolesAuthorizationDelegate();
         setField(authorizationDelegate, "accessRolesProvider",
                 accessRolesProvider);
         setField(authorizationDelegate, "sessionFactory", sessionFactory);
 
-        when(sessionFactory.getInternalSession()).thenReturn(mockSession);
+        when(sessionFactory.getInternalSession()).thenReturn(mockFedoraSession);
 
         when(principal.getName()).thenReturn("user");
         allPrincipals = singleton(principal);
 
+        when(mockFedoraSession.getJcrSession()).thenReturn(mockSession);
         when(mockSession.getAttribute(FEDORA_USER_PRINCIPAL)).thenReturn(
                 principal);
         when(mockSession.getAttribute(FEDORA_ALL_PRINCIPALS)).thenReturn(

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AbstractRolesAuthorizationDelegate.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AbstractRolesAuthorizationDelegate.java
@@ -18,6 +18,7 @@
 package org.fcrepo.auth.roles.common;
 
 import static java.util.stream.Collectors.toSet;
+import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 
 import java.security.Principal;
 import java.util.Arrays;
@@ -34,6 +35,7 @@ import javax.jcr.Session;
 
 import org.fcrepo.auth.common.FedoraAuthorizationDelegate;
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.modeshape.jcr.value.Path;
 import org.slf4j.Logger;
@@ -98,10 +100,10 @@ public abstract class AbstractRolesAuthorizationDelegate implements FedoraAuthor
         }
 
         try {
-            final Session internalSession = sessionFactory.getInternalSession();
+            final FedoraSession internalSession = sessionFactory.getInternalSession();
             final Map<String, Collection<String>> acl =
                     accessRolesProvider.findRolesForPath(absPath,
-                            internalSession);
+                            getJcrSession(internalSession));
             roles = resolveUserRoles(acl, allPrincipals);
             LOGGER.debug("roles for this request: {}", roles);
         } catch (final RepositoryException e) {
@@ -166,10 +168,10 @@ public abstract class AbstractRolesAuthorizationDelegate implements FedoraAuthor
                                                final Set<Principal> allPrincipals,
                                                final Set<String> parentRoles) {
         try {
-            final Session internalSession = sessionFactory.getInternalSession();
+            final FedoraSession internalSession = sessionFactory.getInternalSession();
             LOGGER.debug("Recursive child remove permission checks for: {}",
                     parentPath);
-            final Item item = internalSession.getItem(parentPath);
+            final Item item = getJcrSession(internalSession).getItem(parentPath);
             if (!item.isNode()) {
                 // this is a property and has no children...
                 return true;

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -46,6 +45,7 @@ import javax.ws.rs.core.UriInfo;
 
 import org.fcrepo.http.commons.AbstractResource;
 import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
+import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -76,7 +76,7 @@ public class AccessRoles extends AbstractResource {
 
 
     @Inject
-    protected Session session;
+    protected FedoraSession session;
 
     @Inject
     @Optional
@@ -152,7 +152,7 @@ public class AccessRoles extends AbstractResource {
                 }
             }
         } finally {
-            session.logout();
+            session.expire();
         }
         return response.build();
     }
@@ -182,7 +182,7 @@ public class AccessRoles extends AbstractResource {
             } else {
                 this.getAccessRolesProvider().postRoles(getJcrNode(resource), data);
             }
-            session.save();
+            session.commit();
             LOGGER.debug("Saved access roles {}", data);
             response =
                     Response.created(getUriInfo().getBaseUriBuilder()
@@ -191,7 +191,7 @@ public class AccessRoles extends AbstractResource {
         } catch (final IllegalArgumentException e) {
             throw new WebApplicationException(e, Response.status(Status.BAD_REQUEST).build());
         } finally {
-            session.logout();
+            session.expire();
         }
 
         return response.build();
@@ -242,10 +242,10 @@ public class AccessRoles extends AbstractResource {
             }
 
             this.getAccessRolesProvider().deleteRoles(node);
-            session.save();
+            session.commit();
             return Response.noContent().build();
         } finally {
-            session.logout();
+            session.expire();
         }
     }
 


### PR DESCRIPTION
Addresses: https://jira.duraspace.org/browse/FCREPO-1868

Depends on https://github.com/fcrepo4/fcrepo4/pull/1123