### PR TITLE
Transfer repo to the 'fcrepo-exts' GitHub org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,4 +35,4 @@ Example:
 * Could this change impact execution of existing code?
 
 # Interested parties
-Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
+Tag (@ mention) interested parties or, if unsure, @fcrepo/committers

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 fcrepo-module-auth-rbacl
 ========================
 
-[![Build Status](https://travis-ci.org/fcrepo4-exts/fcrepo-module-auth-rbacl.png?branch=master)](https://travis-ci.org/fcrepo4-exts/fcrepo-module-auth-rbacl)
+[![Build Status](https://travis-ci.org/fcrepo-exts/fcrepo-module-auth-rbacl.png?branch=master)](https://travis-ci.org/fcrepo-exts/fcrepo-module-auth-rbacl)
 
 ### WARNING
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,11 @@
   </repositories>
 
   <scm>
-    <connection>scm:git:git://github.com/fcrepo4-exts/${project.artifactId}.git
+    <connection>scm:git:git://github.com/fcrepo-exts/${project.artifactId}.git
     </connection>
-    <developerConnection>scm:git:git@github.com:fcrepo4-exts/${project.artifactId}.git
+    <developerConnection>scm:git:git@github.com:fcrepo-exts/${project.artifactId}.git
     </developerConnection>
-    <url>https://github.com/fcrepo4-exts/fcrepo-module-auth-rbacl</url>
+    <url>https://github.com/fcrepo-exts/fcrepo-module-auth-rbacl</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
No functional change.
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
